### PR TITLE
chore: Add GitHub labels configuration and sync workflow

### DIFF
--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -1,0 +1,74 @@
+# Default GitHub labels
+- color: d73a4a
+  name: bug
+  description: Something isn't working
+- color: 0075ca
+  name: documentation
+  description: Improvements or additions to documentation
+- color: 0366d6
+  name: dependencies
+  description: Pull requests that update a dependency file
+- color: cfd3d7
+  name: duplicate
+  description: This issue or pull request already exists
+- color: a2eeef
+  name: enhancement
+  description: Functionality that enhances existing features
+- color: 7057ff
+  name: good first issue
+  description: Good for newcomers
+- color: 008672
+  name: help wanted
+  description: We are looking for community help
+- color: e4e669
+  name: invalid
+  description: This doesn't seem right
+- color: d876e3
+  name: question
+  description: Further information is requested
+- color: d876e3
+  name: wontfix
+  description: The issue is expected and will not be fixed
+# Release Please
+- color: ededed
+  name: "autorelease: pending"
+  description:
+- color: ededed
+  name: "autorelease: tagged"
+  description:
+- color: ededed
+  name: "autorelease: triggered"
+  description:
+- color: ededed
+  name: "autorelease: snapshot"
+  description:
+- color: ededed
+  name: "autorelease: published"
+  description:
+# Languages
+- color: 2b67c6
+  name: python
+  description: Pull requests that update Python code
+- color: 00ff1e
+  name: typescript
+  description: Pull requests that update TypeScript code
+- color: 000000
+  name: github_actions
+  description: Pull requests that update GitHub Actions code
+- color: 66A615
+  name: just
+  description: Pull requests that update Just code
+- color: 00ff44
+  name: shell
+  description: Pull requests that update Shell code
+# Custom
+- color: 00f2de
+  name: end_to_end_tests
+  description: Pull requests that update end to end tests
+# Components
+- color: f27100
+  name: dashboard
+  description: Pull requests that update dashboard code
+- color: ff0073
+  name: git_hooks
+  description: Pull requests that update git hooks

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,27 @@
+name: "Sync labels"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/other-configurations/labels.yml
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  configure-labels:
+    runs-on: ubuntu-latest
+    name: Configure Labels
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: micnncim/action-label-syncer@v1.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          manifest: .github/other-configurations/labels.yml


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new GitHub workflow for synchronising labels and a configuration file for defining custom labels. The new workflow, `sync-labels.yml`, automatically updates repository labels when changes are pushed to the `labels.yml` file in the main branch.

The `labels.yml` file defines a comprehensive set of labels, including:

- Default GitHub labels (e.g., bug, documentation, enhancement)
- Release Please automation labels
- Language-specific labels (Python, TypeScript, GitHub Actions, Just, Shell)
- Custom labels for end-to-end tests
- Component-specific labels (dashboard, git hooks)

This addition will help maintain consistent labelling across the repository, improving issue and pull request organisation and management.

fixes #8