### PR TITLE
chore: Add PR labeler configuration and workflow

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -1,0 +1,48 @@
+# labels auto assigned to PR, keep in sync with labels.yml
+documentation:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["README.md", "docs/**"]
+dependencies:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/poetry.lock", "package-lock.json"]
+      - head-branch: ["^dependabot"]
+python:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["*.py", "**/*.py"]
+typescript:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              ["*.ts", "*.tsx", "**/*.ts", "**/*.tsx", "**/tsconfig.json"]
+just:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["Justfile", "**/*.just"]
+shell:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/*.sh"]
+github_actions:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [".github/workflows/*", ".github/workflows/**/*"]
+end-to-end-tests:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["tests/end_to_end/**/*"]
+analyser:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["analyser/**"]
+dashboard:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["dashboard/**"]
+git-hooks:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["githooks/**"]

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -25,3 +25,12 @@ jobs:
         uses: deepakputhraya/action-pr-title@v1.0.2
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix
+  labeller:
+    name: Labeller
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/other-configurations/labeller.yml
+          sync-labels: true


### PR DESCRIPTION
# Pull Request

## Description

This PR introduces automated label management for the repository. It adds two new configuration files and updates the pull request checks workflow.

The `.github/other-configurations/labeller.yml` file defines rules for automatically assigning labels to pull requests based on file changes and branch names. This includes labels for documentation, dependencies, various programming languages, and specific components of the project.

The `.github/other-configurations/labels.yml` file defines a set of standardised labels for the repository, including default GitHub labels, release-related labels, language-specific labels, and custom labels for different components of the project.

The pull request checks workflow (`.github/workflows/pull-request-checks.yml`) is updated to include a new job that applies labels to pull requests using the defined configuration.

A new workflow file, `.github/workflows/sync-labels.yml`, is added to automatically synchronise the repository's labels with the defined configuration when changes are pushed to the main branch.

These changes will help streamline the pull request process by automatically categorising contributions and ensuring consistent labelling across the repository.

fixes #9