### PR TITLE
chore: Add Markdown link checker configuration and workflow

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,0 +1,7 @@
+dirs:
+  - ./
+  - ./docs
+excludedFiles:
+  - ./CHANGELOG.md
+aliveStatusCodes:
+  - 200

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -49,3 +49,21 @@ jobs:
           VALIDATE_TYPESCRIPT_STANDARD: false
           VALIDATE_TSX: false
           VALIDATE_TSX_PRETTIER: false
+
+  check-markdown-links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check Markdown links
+        uses: UmbrellaDocs/action-linkspector@v1.2.2
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          config_file: .github/other-configurations/.linkspector.yml
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new GitHub Actions workflow step to check Markdown links in the repository. The workflow uses the UmbrellaDocs/action-linkspector action to validate links in Markdown files.

A new configuration file `.github/other-configurations/.linkspector.yml` has been added to specify the directories to scan, files to exclude, and acceptable HTTP status codes for link validation.

The code-quality.yml workflow file has been updated to include this new step, which runs on Ubuntu and uses a GitHub token for authentication. The step is configured to fail on errors and provide feedback through GitHub PR reviews.

This enhancement will help maintain the integrity of documentation links throughout the project.

fixes #12