### PR TITLE
chore: Update PR labeler configuration

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -30,19 +30,15 @@ github_actions:
       - changed-files:
           - any-glob-to-any-file:
               [".github/workflows/*", ".github/workflows/**/*"]
-end-to-end-tests:
+end_to_end_tests:
   - any:
       - changed-files:
           - any-glob-to-any-file: ["tests/end_to_end/**/*"]
-analyser:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file: ["analyser/**"]
 dashboard:
   - any:
       - changed-files:
           - any-glob-to-any-file: ["dashboard/**"]
-git-hooks:
+git_hooks:
   - any:
       - changed-files:
           - any-glob-to-any-file: ["githooks/**"]


### PR DESCRIPTION
# Pull Request

## Description

This change updates the labeller configuration file to improve consistency and accuracy in labelling pull requests. The modifications include:

1. Renamed the "end-to-end-tests" label to "end_to_end_tests" for better consistency with other label names.

2. Removed the "analyser" label and its associated file matching rules.

3. Renamed the "git-hooks" label to "git_hooks" to maintain a consistent naming convention using underscores instead of hyphens.

These adjustments will help streamline the labelling process and ensure that pull requests are categorised more accurately based on the files changed.

fixes #42