### PR TITLE
chore: Add size labels to GitHub configuration

### DIFF
--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -72,3 +72,22 @@
 - color: ff0073
   name: git_hooks
   description: Pull requests that update git hooks
+# Sizes
+- color: 00ff22
+  name: size/XS
+  description: Extra Small Pull Request
+- color: 03a319
+  name: size/S
+  description: Small Pull Request
+- color: f2bb05
+  name: size/M
+  description: Medium Pull Request
+- color: fc7e08
+  name: size/L
+  description: Large Pull Request
+- color: ad2e03
+  name: size/XL
+  description: Extra Large Pull Request
+- color: 751f01
+  name: size/XXL
+  description: Extra Extra Large Pull Request


### PR DESCRIPTION

# Pull Request

## Description

This change adds new labels to categorise pull requests based on their size. The following size labels have been introduced:

- size/XS: Extra Small Pull Request (colour: 00ff22)
- size/S: Small Pull Request (colour: 03a319)
- size/M: Medium Pull Request (colour: f2bb05)
- size/L: Large Pull Request (colour: fc7e08)
- size/XL: Extra Large Pull Request (colour: ad2e03)
- size/XXL: Extra Extra Large Pull Request (colour: 751f01)

These new labels will help in quickly identifying the scope and complexity of pull requests, facilitating more efficient review processes and project management.

fixes #53