### PR TITLE
ci: Add size labels to pull requests

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -25,8 +25,9 @@ jobs:
         uses: deepakputhraya/action-pr-title@v1.0.2
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix
+
   labeller:
-    name: Labeller
+    name: Label Pull Request
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5.0.0
@@ -34,3 +35,8 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
+
+      - name: Add Size Labels
+        uses: pascalgn/size-label-action@v0.5.5
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Pull Request

## Description

This change enhances the pull request checks workflow by adding a new job to label pull requests based on their size. The following modifications were made:

1. Renamed the "Labeller" job to "Label Pull Request" for clarity.
2. Added a new "Add Size Labels to Pull Request" job that runs after the initial labelling job.
3. Implemented the size labelling using the `pascalgn/size-label-action@v0.5.5` action.
4. Configured the size labelling job to use the `GITHUB_TOKEN` secret for authentication.

These changes will help categorise pull requests based on their size, making it easier for reviewers to prioritise and manage incoming changes.

fixes #54