### PR TITLE
chore: Add size labels to PR labeller workflow

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -30,7 +30,8 @@ jobs:
     name: Label Pull Request
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5.0.0
+      - name: Label Pull Request
+        uses: actions/labeler@v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configurations/labeller.yml
@@ -40,3 +41,13 @@ jobs:
         uses: pascalgn/size-label-action@v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          with:
+          sizes: >
+            {
+              "0": "XS",
+              "20": "S",
+              "50": "M",
+              "200": "L",
+              "500": "XL",
+              "1000": "XXL"
+            }


### PR DESCRIPTION
# Pull Request

## Description

This change enhances the pull request labelling process in the GitHub Actions workflow. It adds a name to the labeller step for improved readability and introduces size labelling for pull requests.

The size labelling configuration is added to the `size-label-action` step, defining six size categories:
- XS: 0-19 lines
- S: 20-49 lines
- M: 50-199 lines
- L: 200-499 lines
- XL: 500-999 lines
- XXL: 1000+ lines

These changes will help categorise pull requests more effectively, providing quick visual feedback on the scope of changes in each PR.

fixes #58