### PR TITLE
chore: Update PR size label thresholds

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -41,13 +41,13 @@ jobs:
         uses: pascalgn/size-label-action@v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          with:
+        with:
           sizes: >
             {
               "0": "XS",
-              "20": "S",
-              "50": "M",
+              "40": "S",
+              "100": "M",
               "200": "L",
-              "500": "XL",
-              "1000": "XXL"
+              "800": "XL",
+              "2000": "XXL"
             }


### PR DESCRIPTION
# Pull Request

## Description

This change updates the size thresholds for the pull request size labelling action. The new thresholds are:

- XS: 0-39 lines
- S: 40-99 lines
- M: 100-199 lines
- L: 200-799 lines
- XL: 800-1999 lines
- XXL: 2000+ lines

These adjustments allow for more granular categorisation of pull requests based on their size, which can help in prioritising reviews and managing complexity.

fixes #61