### PR TITLE
chore: Add VSCode settings for Python development

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "ruff.configuration": "tests/pyproject.toml",
+  "[python]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit"
+    }
+  },
+  "python.analysis.inlayHints.pytestParameters": true,
+  "files.exclude": {
+    ".ruff_cache": true,
+    ".pytest_cache": true,
+    "**/__pycache__": true,
+    "**/.ruff_cache": true,
+    "**/.pytest_cache": true
+  },
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": {
+    "pyproject.toml": "__init__.py, poetry.lock, coverage.xml, .coverage, .gitignore",
+    "package.json": "package-lock.json, eslint.config.js, .gitignore, tsconfig.json, vite.config.*"
+  }
+}


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new `.vscode/settings.json` file to improve the development experience in Visual Studio Code. The settings include:

- Configuration for the Ruff linter, pointing to a specific `pyproject.toml` file in the tests directory.
- Automatic code actions on save for Python files.
- Enabling pytest parameter inlay hints for better readability.
- Hiding certain directories and files from the file explorer to reduce clutter.
- Enabling file nesting in the explorer, with specific patterns for `pyproject.toml` and `package.json`.

These settings aim to streamline the development workflow, enhance code quality, and improve the overall organisation of the project within VS Code.

fixes #66