### PR TITLE
chore: Update Repository Labels

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -2,7 +2,17 @@
 documentation:
   - any:
       - changed-files:
-          - any-glob-to-any-file: ["README.md", "docs/**"]
+          - any-glob-to-any-file: ["README.md", "*.md", "docs/**"]
+markdown:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [
+                "docs/*.md",
+                "*.md",
+                "LICENSE",
+                ".github/pull_request_template.md",
+              ]
 dependencies:
   - any:
       - changed-files:
@@ -28,8 +38,7 @@ shell:
 github_actions:
   - any:
       - changed-files:
-          - any-glob-to-any-file:
-              [".github/workflows/*", ".github/workflows/**/*"]
+          - any-glob-to-any-file: [".github/workflows/*", ".github/actions/*"]
 end_to_end_tests:
   - any:
       - changed-files:

--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -61,6 +61,9 @@
 - color: 00ff44
   name: shell
   description: Pull requests that update Shell code
+- color: 1900ff
+  name: markdown
+  description: Pull requests that update Markdown documentation
 # Custom
 - color: 00f2de
   name: end_to_end_tests


### PR DESCRIPTION
## Description

This pull request includes changes to the `.github/other-configurations/labeller.yml` and `.github/other-configurations/labels.yml` files to improve the labeling configuration for different types of file changes. The most important changes include adding a new label for Markdown files and updating the file patterns for existing labels.

Labeling configuration improvements:

* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L5-R15): Added a new `markdown` label with specific file patterns for Markdown files such as `*.md`, `LICENSE`, and `.github/pull_request_template.md`.
* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L5-R15): Updated the `documentation` label to include `*.md` files.
* [`.github/other-configurations/labeller.yml`](diffhunk://#diff-b490f987d9b055ce6e06e37d13763d61f6e0d5ee349b390bbb910f8d88ff36b9L31-R41): Modified the `github_actions` label to include files in the `.github/actions/*` directory.
* [`.github/other-configurations/labels.yml`](diffhunk://#diff-c1b32711b0f3da3f5c7007cfaa4d9e94ae5430fea1f4e1256f6210bc6988553dR64-R66): Added a new `markdown` label with a description for pull requests that update Markdown documentation.

Fixes #100