### PR TITLE
chore: Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,10 @@ updates:
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
@@ -19,7 +22,10 @@ updates:
     commit-message:
       prefix: "deps(typescript)"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       typescript:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the Dependabot configuration in the `.github/dependabot.yml` file. The updates adjust the scheduling for dependency updates related to GitHub Actions and TypeScript.

Scheduling changes:

* Updated the schedule for GitHub Actions dependency updates to run weekly on Saturdays at 01:00 in the Europe/London timezone.
* Updated the schedule for TypeScript dependency updates to run weekly on Saturdays at 01:00 in the Europe/London timezone.

Fixes #91 