### PR TITLE
ci: Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Set up Node
+        uses: actions/setup-node@v4.1.0
+        with:
+          node-version: 22
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Setup Pages
+        uses: actions/configure-pages@v5.0.0
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          path: "./dist"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new workflow for deploying to GitHub Pages. The workflow is triggered by pushes to the `main` branch and can also be manually triggered. It includes steps for checking out the repository, setting up Node.js, installing dependencies, building the project, configuring GitHub Pages, uploading the build artifacts, and deploying to GitHub Pages.

Key changes include:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R42): Added a new GitHub Actions workflow named "Deploy to GitHub Pages" that runs on `ubuntu-latest`. The workflow includes steps for checking out the repository, setting up Node.js, installing dependencies, building the project, configuring GitHub Pages, uploading build artifacts, and deploying to GitHub Pages.

Fixes #18
