### PR TITLE
ci: Separate CodeLimit Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -106,6 +106,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: "Run Code Limit"
-        uses: getcodelimit/codelimit-action@8ee70f8d3d5b984130e46fb8ccbe229f5e1d68d0
+        uses: getcodelimit/codelimit-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -100,12 +100,13 @@ jobs:
   run-code-limit:
     name: Run Code Limit
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: Checkout Repository
+      - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: "Run Code Limit"
         uses: getcodelimit/codelimit-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -97,6 +97,14 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.27.5
 
+  run-code-limit:
+    name: Run Code Limit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
       - name: "Run Code Limit"
         uses: getcodelimit/codelimit-action@8ee70f8d3d5b984130e46fb8ccbe229f5e1d68d0
         with:

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -109,4 +109,4 @@ jobs:
         uses: getcodelimit/codelimit-action@8ee70f8d3d5b984130e46fb8ccbe229f5e1d68d0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          upload: true
+

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -109,4 +109,3 @@ jobs:
         uses: getcodelimit/codelimit-action@8ee70f8d3d5b984130e46fb8ccbe229f5e1d68d0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow to enforce code size limits. The most important changes include the addition of a new job named `run-code-limit` in the `.github/workflows/code-checks.yml` file.

Changes to GitHub Actions workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R100-R107): Added a new job `run-code-limit` to the workflow, which includes steps to checkout the repository and run the `getcodelimit/codelimit-action`.

Fixes #107
Fixes #108