### PR TITLE
ci: Upgrade Markdown Link Checker

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -52,14 +52,14 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        uses: UmbrellaDocs/action-linkspector@v1.2.5
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small update to the `.github/workflows/code-checks.yml` file. The change updates the environment and action versions used for checking Markdown links.

* Updated the `runs-on` environment from `ubuntu-22.04` to `ubuntu-latest`.
* Updated the `UmbrellaDocs/action-linkspector` version from `v1.2.4` to `v1.2.5`.