### PR TITLE
ci: Run Link Tests

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -157,7 +157,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Node.js with Cache
-        uses: actions/setup-node@v4.1.0
+        uses: actions/setup-node@v4.2.0
         with:
           node-version-file: "dashboard/package.json"
           cache: "npm"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,12 +22,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
-      - name: Set up Node
-        uses: actions/setup-node@v4.1.0
+      - name: Set up Node.js with Cache
+        uses: actions/setup-node@v4.2.0
         with:
-          node-version: 22
+          node-version-file: "dashboard/package.json"
           cache: "npm"
-          cache-dependency-path: "./dashboard/package-lock.json"
+          cache-dependency-path: "dashboard/package-lock.json"
       - name: Install dependencies
         run: rm -rf node_modules && rm -rf package-lock.json && npm install
         working-directory: ./dashboard
@@ -43,3 +43,21 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4.0.5
+
+  link-tests:
+    name: Link Tests
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Run Link Tests
+        uses: JustinBeckwith/linkinator-action@v1.11.0
+        with:
+          paths: https://jackplowman.github.io/status-sentinel
+          recurse: true
+          timeout: 1000
+          markdown: false

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -49,4 +49,4 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4.6.0
+        uses: actions/dependency-review-action@v4.5.0

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -49,4 +49,4 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4.5.0
+        uses: actions/dependency-review-action@v4.6.0


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflows to improve the setup and testing processes. The most important changes include updating the Node.js setup action version, modifying the caching configuration, and adding a new job for link tests.

Updates to Node.js setup and caching:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L160-R160): Updated `actions/setup-node` from version `v4.1.0` to `v4.2.0`.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L25-R30): Updated `actions/setup-node` from version `v4.1.0` to `v4.2.0`, changed `node-version` to use `node-version-file`, and adjusted the `cache-dependency-path`.

Addition of link tests:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R46-R63): Added a new job named `link-tests` to run link tests using `JustinBeckwith/linkinator-action@v1.11.0`.

Fixes #69
