### PR TITLE
ci: Add Python Tests Linting

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -187,3 +187,47 @@ jobs:
         run: just dashboard::prettier-check
       - name: Run ESLint
         run: just dashboard::lint
+
+  run-python-code-checks:
+    name: Run Python Code Checks
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5.4.0
+        with:
+          python-version: 3.13
+      - name: Install Poetry
+        run: pipx install poetry==2.0.1
+      - name: Install dependencies
+        run: just tests::install
+      - name: Generate Ruff Sarif
+        run: just tests::ruff-lint-check
+        env:
+          RUFF_OUTPUT_FORMAT: "sarif"
+          RUFF_OUTPUT_FILE: "ruff-results.sarif"
+        continue-on-error: true
+      - name: Upload Ruff analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3.28.8
+        with:
+          sarif_file: tests/ruff-results.sarif
+          wait-for-processing: true
+      - name: Validates Pyproject
+        run: just tests::pyproject-check
+      - name: Check Python Code Format (Ruff)
+        run: just tests::ruff-format-check
+        env:
+          RUFF_OUTPUT_FORMAT: "github"
+      - name: Check Python Code Linting (Ruff)
+        run: just tests::ruff-lint-check
+        env:
+          RUFF_OUTPUT_FORMAT: "github"


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow for running Python code checks. The most important changes include adding steps for setting up the environment, installing dependencies, and running various Python code checks using the `ruff` tool.

New Python code checks job:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R190-R233): Added a new job `run-python-code-checks` to run Python code checks. This job includes steps for checking out the repository, setting up Just, setting up Python 3.13, installing Poetry and dependencies, generating and uploading Ruff analysis results, validating the `pyproject` file, and checking Python code format and linting using Ruff.

Fixes #159 
