### PR TITLE
ci: Regularly Clear Caches

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -1,0 +1,24 @@
+name: Clean Caches
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  clean-caches:
+    name: Clean GitHub Action Caches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Delete caches
+        run: gh cache delete --all --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions workflow to clean caches periodically. The workflow is set to run on a monthly schedule and can also be triggered manually.

New GitHub Actions workflow:

* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dR1-R24): Added a new workflow named "Clean Caches" that schedules a job to delete GitHub Action caches on the first day of every month and allows manual triggering. The job runs on `ubuntu-latest`, checks out the repository, and deletes all caches using the `gh cache delete` command.