### PR TITLE
chore: Disable Deployment Concurrency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: "pages"
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
   deploy:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `.github/workflows/deploy.yml` file to improve the deployment workflow by adjusting the concurrency settings.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L12-R13): Modified the `concurrency` group to use the `${{ github.workflow }}` variable and added the `cancel-in-progress` option to true.