### PR TITLE
ci: Add GitHub Action Step Name

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -22,7 +22,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: micnncim/action-label-syncer@v1.3.0
+      - name: Sync labelsS
+        uses: micnncim/action-label-syncer@v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor change to the `.github/workflows/sync-labels.yml` file to improve the readability of a workflow step by adding a descriptive name to the `micnncim/action-label-syncer` action.

* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L25-R26): Added the name `Sync labels` to the workflow step that uses the `micnncim/action-label-syncer` action.