### PR TITLE
chore: Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -24,7 +24,7 @@ updates:
       prefix: "deps(typescript)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       typescript:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,8 @@ updates:
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -24,9 +23,8 @@ updates:
     commit-message:
       prefix: "deps(typescript)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       typescript:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration to switch from a daily schedule to a cron-based schedule for dependency updates.

Changes to Dependabot scheduling:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L10-R11): Updated the `github-actions` group to use a cron schedule (`30 7 * * *`) instead of the previous daily schedule.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L27-R27): Updated the `typescript` group to use a cron schedule (`30 7 * * *`) instead of the previous daily schedule.