### PR TITLE
chore: Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,21 @@ version: 2
 
 updates:
   - package-ecosystem: "github-actions"
-    directories:
-      - "/"
+    directory: "/"
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"
@@ -25,9 +28,11 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       typescript:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to enhance Dependabot's behavior and improve the organization of updates. The changes include simplifying directory specifications, adding a timezone for scheduling, and refining group configurations with new attributes and exclusions.

### Dependabot configuration updates:

* Simplified the `directory` field by replacing the list of directories with a single string value (`"/"`) for clarity.
* Added a `timezone` field (`"Europe/London"`) to the `schedule` section to ensure cron jobs run at the correct local time. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R19) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R31-R35)

### Group configuration improvements:

* Introduced the `applies-to` attribute with the value `"version-updates"` for both `github-actions` and `typescript` groups, specifying the scope of updates these groups apply to. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R19) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R31-R35)
* Enhanced the `github-actions` group by adding `exclude-patterns` to prevent updates for paths matching `"super-linter/*"`.