### PR TITLE
chore: Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -136,21 +136,16 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
       - name: Set up Just
-        uses: extractions/setup-just@v2
-      - name: Install Python and UV
-        uses: astral-sh/setup-uv@v5.2.2
-        with:
-          pyproject-file: "tests/pyproject.toml"
-          enable-cache: true
-      - name: Install dependencies
-        run: just tests::install
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uv --project tests run zizmor --format sarif . > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.17
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow for code checks, focusing on modernizing dependencies and simplifying the setup process. The key changes involve upgrading versions of tools and actions, replacing commands with `just` tasks, and streamlining the workflow for better maintainability.

### Dependency and tool updates:
* Updated the `setup-uv` action to use version `v6.0.1` for installing the latest version of `uv`, replacing the older `v5.2.2`.
* Upgraded the `setup-just` action to version `v3` for setting up `Just`.
* Updated the `upload-sarif` action to version `v3.28.17` for uploading SARIF files.

### Workflow simplification:
* Removed the `Install Python and UV` step, as the `setup-uv` action now installs the latest version of `uv` without requiring additional configuration.
* Replaced the direct `uv` command for running `zizmor` with a `just` task (`just zizmor-check-sarif`) for improved readability and consistency.