### PR TITLE
chore: Add Zizmor Commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -37,6 +37,18 @@ gitleaks-detect:
     gitleaks detect --source . > /dev/null
 
 # ------------------------------------------------------------------------------
+# Zizmor
+# ------------------------------------------------------------------------------
+
+# Run zizmor checking
+zizmor-check:
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
+
+# ------------------------------------------------------------------------------
 # Git Hooks
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds support for running Zizmor checks to the `Justfile`. The changes introduce two new commands for performing Zizmor checks, one with default output and another with SARIF-formatted output.

### Added Zizmor commands:
* **`zizmor-check`**: Runs Zizmor checks with the `pedantic` persona.
* **`zizmor-check-sarif`**: Runs Zizmor checks with the `pedantic` persona and outputs results in SARIF format to `results.sarif`.