### PR TITLE
chore: Add pinact commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -49,6 +49,22 @@ zizmor-check-sarif:
     uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
+# Pinact
+# ------------------------------------------------------------------------------
+
+# Run pinact
+pinact-run:
+    pinact run
+
+# Run pinact checking
+pinact-check:
+    pinact run --verify --check
+
+# Run pinact update
+pinact-update:
+    pinact run --update
+
+# ------------------------------------------------------------------------------
 # Git Hooks
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces new commands to the `Justfile` for managing `pinact` operations, alongside existing `zizmor-check` and Git hooks commands.

New `pinact` commands added:

* [`pinact-run`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR51-R66): A command to execute `pinact run`.
* [`pinact-check`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR51-R66): A command to run `pinact` with `--verify` and `--check` options for validation purposes.
* [`pinact-update`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR51-R66): A command to run `pinact` with the `--update` option for updating configurations or dependencies.