### PR TITLE
ci: Add Lefthook Validate Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -88,6 +88,20 @@ jobs:
       - name: Check Justfile Format
         run: just format-check
 
+  lefthook-validate:
+    name: Lefthook Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      - name: Run Lefthook Validate
+        run: uvx lefthook validate
+
   run-codeql-analysis:
     name: CodeQL Analysis
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new job to the GitHub Actions workflow to validate Lefthook configurations. This ensures that the Lefthook setup is correctly configured and adheres to the expected standards.

### Workflow Enhancements:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R91-R104): Added a new `lefthook-validate` job that checks out the repository, installs the latest version of `uv`, and runs `lefthook validate` to validate Lefthook configurations.