### PR TITLE
ci: Change Jobs to Common Pull Request Tasks

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions: {}
+permissions:
+  pull-requests: read
 
 jobs:
   check-pull-request-title:
@@ -16,45 +17,10 @@ jobs:
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: ,build(deps): " # title should start with the given prefix
 
-  labeller:
-    name: Label Pull Request
-    runs-on: ubuntu-latest
+  common-pull-request-tasks:
+    name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    steps:
-      - name: Label Pull Request
-        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          configuration-path: .github/other-configurations/labeller.yml
-          sync-labels: true
-      - name: Add Size Labels
-        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          sizes: >
-            {
-              "0": "XS",
-              "40": "S",
-              "100": "M",
-              "200": "L",
-              "800": "XL",
-              "2000": "XXL"
-            }
-
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Dependency Review
-        uses: actions/dependency-review-action@38ecb5b593bf0eb19e335c03f97670f792489a8b # v4.7.0
-        with:
-          comment-summary-in-pr: on-failure
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@14445779094fde883fdb9f65946fcae6c25f46c0 # v2025.05.14.01
+    secrets:
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description


This pull request updates the `.github/workflows/pull-request-tasks.yml` file to streamline and consolidate pull request workflows by replacing individual jobs with a reusable workflow and adjusting permissions.

### Workflow Consolidation:
* Removed the `labeller` and `dependency-review` jobs and replaced them with a single reusable workflow, `common-pull-request-tasks`, which is defined in an external repository. This change simplifies the workflow configuration and centralizes common tasks.

### Permissions Adjustment:
* Updated the `permissions` section to explicitly set `pull-requests: read` for the workflow, ensuring the workflow has the necessary but minimal permissions.
