### PR TITLE
ci: Migrate to Reusable CodeQL Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -63,27 +63,17 @@ jobs:
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  run-codeql-analysis:
+  codeql-checks:
     name: CodeQL Analysis
-    runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     strategy:
       matrix:
-        language: [python, typescript, actions]
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
-        with:
-          languages: ${{ matrix.language }}
-          queries: security-and-quality
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
+        language: [actions, typescript, python]
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493 # v2025.05.24.01
+    with:
+      language: ${{ matrix.language }}
 
   run-code-limit:
     name: Run CodeLimit


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CodeQL analysis workflow in `.github/workflows/code-checks.yml` to use a reusable workflow, streamlining the configuration and improving maintainability.

### Workflow updates:
* Renamed the `run-codeql-analysis` job to `codeql-checks` for clarity and consistency.
* Replaced the inline CodeQL setup and analysis steps with a reference to a reusable workflow (`JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493`). This reduces redundancy and centralizes the workflow logic.
* Updated the `language` matrix to reorder the languages (`actions, typescript, python`) for better readability and consistency.
* Adjusted permissions to explicitly set `contents: read` and `security-events: write`, ensuring the workflow has the necessary but minimal permissions.