### PR TITLE
ci: Switch npm Install to npm ci in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
           cache: "npm"
           cache-dependency-path: "dashboard/package-lock.json"
       - name: Install dependencies
-        run: rm -rf node_modules && rm -rf package-lock.json && npm install
+        run: npm ci
         working-directory: ./dashboard
       - name: Build
         run: npm run build


### PR DESCRIPTION
# Pull Request

## Description

This pull request simplifies the dependency installation process in the deployment workflow by replacing the existing commands with a more efficient and reliable alternative.

Workflow improvement:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L37-R37): Updated the "Install dependencies" step to use `npm ci` instead of manually removing `node_modules` and `package-lock.json` followed by `npm install`. This ensures a clean and faster installation process using the exact dependencies specified in `package-lock.json`.
