### PR TITLE
ci: Remove CodeLimit Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -76,21 +76,6 @@ jobs:
     with:
       language: ${{ matrix.language }}
 
-  run-code-limit:
-    name: Run CodeLimit
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: "Run CodeLimit"
-        uses: getcodelimit/codelimit-action@a036c6897be9ccf69cde9dfe50eafa8cd79c98f8 # v1
-
   run-typescript-code-checks:
     name: Run TypeScript Code Checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the `run-code-limit` job from the `.github/workflows/code-checks.yml` file. The change simplifies the workflow by eliminating the CodeLimit checks.

Removed workflow job:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L79-L93): The `run-code-limit` job, including its steps and dependencies, has been removed to streamline the workflow and reduce complexity.