### PR TITLE
chore: Override Python Dependencies

### DIFF
--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -14,6 +14,8 @@ dev = ["ruff==0.12.0", "ty==0.0.1a16"]
 
 [tool.uv]
 required-version = "~=0.8.0"
+package = false
+override-dependencies = ["urllib3==2.5.0"]
 
 [tool.ruff]
 target-version = "py313"

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 2
 requires-python = ">=3.13"
 
+[manifest]
+overrides = [{ name = "urllib3", specifier = "==2.5.0" }]
+
 [[package]]
 name = "certifi"
 version = "2025.1.31"
@@ -310,9 +313,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268, upload-time = "2024-12-22T07:47:30.032Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369, upload-time = "2024-12-22T07:47:28.074Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
 ]


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a configuration update to the `tests/pyproject.toml` file, focusing on dependency management and tooling settings.

### Configuration updates:

* Added `package = false` under `[tool.uv]` to disable packaging for the `uv` tool.
* Introduced `override-dependencies = ["urllib3==2.5.0"]` under `[tool.uv]` to specify a fixed version of the `urllib3` dependency.