### PR TITLE
chore: Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the file pattern for labeling documentation-related files in the `.github/other-configurations/labeller.yml` configuration. The most notable change is the correction of the license file name to match the project's naming convention.

Labeling configuration update:

* Changed the documentation label pattern from `LICENSE` to `LICENCE` in the `markdown:` section to match the actual file name used in the repository.