### PR TITLE
chore: Update Prek Freeze Command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -87,7 +87,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate
+    prek update --freeze
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py
@@ -100,4 +100,3 @@ prek-update-additional-dependencies:
 update:
     just pinact-update
     just prek-update
-    just prek-update-additional-dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the `Justfile` by changing the way the Prek dependencies are updated. The main change is switching the Prek update command to use the `--freeze` flag, and removing the step that updates additional dependencies during the standard update process.

- Prek update process:
  * Changed the `prek-update-hooks` recipe to use `prek update --freeze` instead of `prek autoupdate` to ensure dependency versions are locked during updates.
  * Removed the call to `prek-update-additional-dependencies` from the main `update` recipe, so additional dependencies are no longer updated as part of the standard update process.